### PR TITLE
constant values were incorrectly determined or not being determined

### DIFF
--- a/enum_test.go
+++ b/enum_test.go
@@ -10,11 +10,11 @@ import (
 func TestEnumMembers_add(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
 		var v enumMembers
-		v.add("foo", nil)
-		v.add("z", ptrString("X"))
-		v.add("bar", nil)
-		v.add("y", ptrString("Y"))
-		v.add("x", ptrString("X"))
+		v.add("foo")
+		v.addWithConstVal("z", "X")
+		v.add("bar")
+		v.addWithConstVal("y", "Y")
+		v.addWithConstVal("x", "X")
 
 		if want, got := []string{"foo", "z", "bar", "y", "x"}, v.Names; !reflect.DeepEqual(want, got) {
 			t.Errorf("want %v, got %v", want, got)
@@ -81,11 +81,15 @@ func TestFindEnumMembers(t *testing.T) {
 	})
 
 	got := make(map[string]*enumMembers)
-	findEnumMembers(enumpkg.Syntax, enumpkg.TypesInfo, knownEnumTypes, func(memberName, typeName string, constVal *string) {
+	findEnumMembers(enumpkg.Syntax, enumpkg.TypesInfo, knownEnumTypes, func(memberName, typeName string, constVal string, constValOk bool) {
 		if _, ok := got[typeName]; !ok {
 			got[typeName] = &enumMembers{}
 		}
-		got[typeName].add(memberName, constVal)
+		if constValOk {
+			got[typeName].addWithConstVal(memberName, constVal)
+		} else {
+			got[typeName].add(memberName)
+		}
 	})
 
 	checkEnums(t, got)
@@ -109,10 +113,12 @@ func checkEnums(t *testing.T, got map[string]*enumMembers) {
 		"IotaEnum": {
 			[]string{"IotaA", "IotaB"},
 			map[string]string{
-				"IotaA": `2`,
+				"IotaA": `0`,
+				"IotaB": `2`,
 			},
 			map[string][]string{
-				`2`: {"IotaA"},
+				`0`: {"IotaA"},
+				`2`: {"IotaB"},
 			},
 		},
 		"RepeatedValue": {
@@ -216,10 +222,12 @@ func checkEnums(t *testing.T, got map[string]*enumMembers) {
 		"Float64Enum": {
 			[]string{"Float64A", "Float64B"},
 			map[string]string{
-				"Float64A": `1`,
+				"Float64A": `0`,
+				"Float64B": `1`,
 			},
 			map[string][]string{
-				`1`: {"Float64A"},
+				`0`: {"Float64A"},
+				`1`: {"Float64B"},
 			},
 		},
 	}

--- a/hitlist_test.go
+++ b/hitlist_test.go
@@ -16,7 +16,7 @@ func TestHitlist(t *testing.T) {
 		NameToValue: map[string]string{
 			"A": "1",
 			"B": "2",
-			// C has no AST value
+			// C has no constVal
 			"D": "2",
 			"E": "3",
 			"F": "2",

--- a/testdata/src/duplicateenumvalue/strategyvalue/value.go
+++ b/testdata/src/duplicateenumvalue/strategyvalue/value.go
@@ -21,10 +21,8 @@ func _p() {
 func _q() {
 	var s duplicateenumvalue.State
 
-	// value-based checks not available for iota enums (implementation detail: since
-	// we cannot determine a constant.Value from AST/type information).
-
-	switch s { // want "^missing cases in switch of type duplicateenumvalue.State: DefaultState$"
+	// should not report missing DefaultState, since it has same value as TamilNadu
+	switch s {
 	case duplicateenumvalue.TamilNadu, duplicateenumvalue.Kerala, duplicateenumvalue.Karnataka:
 	}
 }
@@ -32,14 +30,14 @@ func _q() {
 func _r() {
 	// should report correctly (in union '|' form) when same-valued names are
 	// missing.
+
 	var r duplicateenumvalue.River
 	switch r { // want "^missing cases in switch of type duplicateenumvalue.River: DefaultRiver|Ganga, Kaveri$"
 	case duplicateenumvalue.Yamuna:
 	}
 
-	// reporting should work correctly when constant.Values are not present also.
 	var s duplicateenumvalue.State
-	switch s { // want "^missing cases in switch of type duplicateenumvalue.State: DefaultState, Kerala, TamilNadu$"
+	switch s { // want "^missing cases in switch of type duplicateenumvalue.State: DefaultState|TamilNadu, Kerala$"
 	case duplicateenumvalue.Karnataka:
 	}
 }


### PR DESCRIPTION
Constant values for enum members were being incorrectly determined. This
has been fixed.

Additionally, in some scenarios, the package would fail to determine
constant values when in fact it would be possible to determine them.
This has been fixed; this is most notable when iota is involved.