### PR TITLE
resolve #37: ignore comment directives from nested switches

### DIFF
--- a/switch.go
+++ b/switch.go
@@ -70,7 +70,7 @@ func switchStmtChecker(pass *analysis.Pass, cfg config) nodeVisitor {
 		if _, ok := comments[file]; !ok {
 			comments[file] = ast.NewCommentMap(pass.Fset, file, file.Comments)
 		}
-		if containsIgnoreDirective(comments[file].Filter(sw).Comments()) {
+		if containsIgnoreDirective(comments[file][sw]) {
 			// Skip checking of this switch statement due to ignore directive comment.
 			// Still return true because there may be nested switch statements
 			// that are not to be ignored.

--- a/testdata/src/ignore-comment/ignore_comment.go
+++ b/testdata/src/ignore-comment/ignore_comment.go
@@ -27,7 +27,8 @@ func _b() {
 	var d Direction
 
 	// this should not report.
-	switch d { //exhaustive:ignore
+	//exhaustive:ignore
+	switch d {
 	case N:
 	case S:
 	case W:
@@ -47,7 +48,8 @@ func _nested() {
 	var d Direction
 
 	// this should not report.
-	switch d { //exhaustive:ignore
+	//exhaustive:ignore
+	switch d {
 	case N:
 	case S:
 	case W:
@@ -60,4 +62,24 @@ func _nested() {
 		default:
 		}
 	}
+}
+
+func _reverse_nested() {
+       var d Direction
+
+       // this should report.
+       switch d { // want "^missing cases in switch of type Direction: E, directionInvalid$"
+       case N:
+       case S:
+       case W:
+       default:
+               // this should not report.
+	       //exhaustive:ignore
+               switch d {
+               case N:
+               case S:
+               case W:
+               default:
+               }
+       }
 }


### PR DESCRIPTION
Resolve #37 as suggested by @nishanths by looking for directives purely within the comments directly associated with the switch statement's AST node. Add a unit test to capture the case of directives present in nested switch statements.