### PR TITLE
use AST order to report missing names

### DIFF
--- a/switch_test.go
+++ b/switch_test.go
@@ -60,7 +60,7 @@ func TestDiagnosticMissingMembers(t *testing.T) {
 
 	t.Run("missing some: unique or unknown values", func(t *testing.T) {
 		got := diagnosticMissingMembers(map[string]struct{}{"Yamuna": {}, "Kaveri": {}}, em)
-		want := []string{"Kaveri", "Yamuna"}
+		want := []string{"Yamuna", "Kaveri"}
 		if !reflect.DeepEqual(want, got) {
 			t.Errorf("want %v, got %v", want, got)
 		}
@@ -75,7 +75,7 @@ func TestDiagnosticMissingMembers(t *testing.T) {
 
 	t.Run("missing all", func(t *testing.T) {
 		got := diagnosticMissingMembers(map[string]struct{}{"Ganga": {}, "Kaveri": {}, "Yamuna": {}, "Unspecified": {}}, em)
-		want := []string{"Ganga|Unspecified", "Kaveri", "Yamuna"}
+		want := []string{"Ganga|Unspecified", "Yamuna", "Kaveri"}
 		if !reflect.DeepEqual(want, got) {
 			t.Errorf("want %v, got %v", want, got)
 		}
@@ -114,7 +114,7 @@ func TestMakeDiagnostic(t *testing.T) {
 	want := analysis.Diagnostic{
 		Pos:     1,
 		End:     11,
-		Message: "missing cases in switch of type enumpkg.Biome: Desert, Savanna",
+		Message: "missing cases in switch of type enumpkg.Biome: Savanna, Desert",
 	}
 	if !reflect.DeepEqual(want, got) {
 		t.Errorf("want %+v, got %+v", want, got)

--- a/testdata/src/duplicate-enum-value/otherpkg/otherpkg.go
+++ b/testdata/src/duplicate-enum-value/otherpkg/otherpkg.go
@@ -37,7 +37,7 @@ func _r() {
 	}
 
 	var s d.State
-	switch s { // want "^missing cases in switch of type duplicateenumvalue.State: DefaultState\\|TamilNadu, Kerala$"
+	switch s { // want "^missing cases in switch of type duplicateenumvalue.State: TamilNadu\\|DefaultState, Kerala$"
 	case d.Karnataka:
 	}
 }

--- a/testdata/src/general/x/general.go
+++ b/testdata/src/general/x/general.go
@@ -162,7 +162,7 @@ func _q() {
 	fi, err := os.Lstat(".")
 	fmt.Println(err)
 
-	switch fi.Mode() { // want "^missing cases in switch of type fs.FileMode: ModeDevice, ModePerm, ModeSetgid, ModeSetuid, ModeType$"
+	switch fi.Mode() { // want "^missing cases in switch of type fs.FileMode: ModeDevice, ModeSetuid, ModeSetgid, ModeType, ModePerm$"
 	case os.ModeDir:
 	case os.ModeAppend:
 	case os.ModeExclusive:

--- a/testdata/src/ignore-enum-member/same_value.go
+++ b/testdata/src/ignore-enum-member/same_value.go
@@ -13,6 +13,6 @@ const (
 // The member Standard, though it has the same constant value as User, must
 // still be reported in the diagnostic.
 func _c(a Access) {
-	switch a { // want "^missing cases in switch of type Access: Group, Standard$"
+	switch a { // want "^missing cases in switch of type Access: Standard, Group$"
 	}
 }


### PR DESCRIPTION
Sort missing names in declaration order in error report.
fixes #41