### PR TITLE
check comments for parent nodes

### DIFF
--- a/testdata/src/enforce-comment/enforce_comment.go
+++ b/testdata/src/enforce-comment/enforce_comment.go
@@ -73,12 +73,28 @@ func _reverse_nested() {
 	case S:
 	case W:
 	default:
-		// this should not report.
-		switch d {
+		// this should report.
+		switch d { // want "^missing cases in switch of type Direction: E, directionInvalid$"
 		case N:
 		case S:
 		case W:
 		default:
+		}
+	}
+}
+
+func _comment_can_relate_to_parent_node() {
+	var d Direction
+
+	//exhaustive:enforce
+	if true {
+		for {
+			switch d { // want "^missing cases in switch of type Direction: E, directionInvalid$"
+			case N:
+			case S:
+			case W:
+			default:
+			}
 		}
 	}
 }

--- a/testdata/src/ignore-comment/ignore_comment.go
+++ b/testdata/src/ignore-comment/ignore_comment.go
@@ -54,8 +54,8 @@ func _nested() {
 	case S:
 	case W:
 	default:
-		// this should report.
-		switch d { // want "^missing cases in switch of type Direction: E, directionInvalid$"
+		// this should not report.
+		switch d {
 		case N:
 		case S:
 		case W:
@@ -80,6 +80,22 @@ func _reverse_nested() {
 		case S:
 		case W:
 		default:
+		}
+	}
+}
+
+func _comment_can_relate_to_parent_node() {
+	var d Direction
+
+	//exhaustive:ignore
+	if true {
+		for {
+			switch d {
+			case N:
+			case S:
+			case W:
+			default:
+			}
 		}
 	}
 }


### PR DESCRIPTION
Now comments `//exhaustive:ignore` and `//exhaustive:enforce` can be defined on parent nodes, not only on `switch` statement.
See discussion https://github.com/nishanths/exhaustive/issues/35#issuecomment-1168796083

```go
func DoSomething(e Enum) string {
	//exhaustive:ignore
	if true {
		switch e {
		case A:
			return "A"
		case B:
			return "B"
		}
	}
}
```