### PR TITLE
Resolves #70: add stricter comment directive scan

### DIFF
--- a/comment.go
+++ b/comment.go
@@ -25,7 +25,8 @@ const (
 
 type directiveSet int64
 
-func parseDirectiveSet(commentGroups []*ast.CommentGroup) (out directiveSet) {
+func parseDirectives(commentGroups []*ast.CommentGroup) directiveSet {
+	var out directiveSet
 	for _, commentGroup := range commentGroups {
 		for _, comment := range commentGroup.List {
 			commentLine := comment.Text
@@ -48,10 +49,10 @@ func parseDirectiveSet(commentGroups []*ast.CommentGroup) (out directiveSet) {
 			}
 		}
 	}
-	return
+	return out
 }
 
-func (d directiveSet) hasDirective(directive directive) bool {
+func (d directiveSet) has(directive directive) bool {
 	return int64(d)&int64(directive) != 0
 }
 

--- a/comment.go
+++ b/comment.go
@@ -1,7 +1,6 @@
 package exhaustive
 
 import (
-	"errors"
 	"fmt"
 	"go/ast"
 	"go/token"
@@ -14,11 +13,6 @@ const (
 	enforceComment                    = "enforce"
 	ignoreDefaultCaseRequiredComment  = "ignore-default-case-required"
 	enforceDefaultCaseRequiredComment = "enforce-default-case-required"
-)
-
-var (
-	errConflictingDirectives = errors.New("conflicting directives")
-	errInvalidDirective      = errors.New("invalid directive")
 )
 
 type directive int64
@@ -54,7 +48,7 @@ func parseDirectives(commentGroups []*ast.CommentGroup) (directiveSet, error) {
 			case enforceDefaultCaseRequiredComment:
 				out |= enforceDefaultCaseRequiredDirective
 			default:
-				return out, fmt.Errorf("%w %q", errInvalidDirective, directive)
+				return out, fmt.Errorf("invalid directive %q", directive)
 			}
 		}
 	}
@@ -68,14 +62,11 @@ func (d directiveSet) has(directive directive) bool {
 func (d directiveSet) validate() error {
 	enforceConflict := ignoreDirective | enforceDirective
 	if d&(directiveSet(enforceConflict)) == directiveSet(enforceConflict) {
-		return fmt.Errorf("%w %q and %q", errConflictingDirectives, ignoreComment, enforceComment)
+		return fmt.Errorf("conflicting directives %q and %q", ignoreComment, enforceComment)
 	}
 	defaultCaseRequiredConflict := ignoreDefaultCaseRequiredDirective | enforceDefaultCaseRequiredDirective
 	if d&(directiveSet(defaultCaseRequiredConflict)) == directiveSet(defaultCaseRequiredConflict) {
-		return fmt.Errorf(
-			"%w %q and %q", errConflictingDirectives,
-			ignoreDefaultCaseRequiredComment, enforceDefaultCaseRequiredComment,
-		)
+		return fmt.Errorf("conflicting directives %q and %q", ignoreDefaultCaseRequiredComment, enforceDefaultCaseRequiredComment)
 	}
 	return nil
 }

--- a/comment_test.go
+++ b/comment_test.go
@@ -55,7 +55,7 @@ func TestDirectives(t *testing.T) {
 				},
 			},
 		}
-		directives := parseDirectiveSet(commentGroups)
+		directives := parseDirectives(commentGroups)
 		if directives != 0 {
 			t.Errorf("unexpected directives: %d", directives)
 		}
@@ -87,7 +87,7 @@ func TestDirectives(t *testing.T) {
 				},
 			},
 		}
-		directives := parseDirectiveSet(commentGroups)
+		directives := parseDirectives(commentGroups)
 		expected := ignoreDirective | enforceDirective |
 			ignoreDefaultCaseRequiredDirective | enforceDefaultCaseRequiredDirective
 
@@ -119,7 +119,7 @@ func TestDirectives(t *testing.T) {
 			},
 		}
 
-		directives := parseDirectiveSet(commentGroups)
+		directives := parseDirectives(commentGroups)
 		if directives != ignoreDirective|enforceDefaultCaseRequiredDirective {
 			t.Errorf("unexpected directives: %d", directives)
 		}

--- a/map.go
+++ b/map.go
@@ -77,7 +77,10 @@ func mapChecker(pass *analysis.Pass, cfg mapConfig, generated boolCache, comment
 			}
 		}
 
-		directives := parseDirectives(relatedComments)
+		directives, err := parseDirectives(relatedComments)
+		if err != nil {
+			pass.Report(makeInvalidDirectiveDiagnostic(lit, err))
+		}
 
 		if !cfg.explicit && directives.has(ignoreDirective) {
 			// Skip checking of this map literal due to ignore

--- a/map.go
+++ b/map.go
@@ -77,13 +77,15 @@ func mapChecker(pass *analysis.Pass, cfg mapConfig, generated boolCache, comment
 			}
 		}
 
-		if !cfg.explicit && hasCommentPrefix(relatedComments, ignoreComment) {
+		directives := parseDirectiveSet(relatedComments)
+
+		if !cfg.explicit && directives.hasDirective(ignoreDirective) {
 			// Skip checking of this map literal due to ignore
 			// comment. Still return true because there may be nested
 			// map literals that are not to be ignored.
 			return true, resultIgnoreComment
 		}
-		if cfg.explicit && !hasCommentPrefix(relatedComments, enforceComment) {
+		if cfg.explicit && !directives.hasDirective(enforceDirective) {
 			return true, resultNoEnforceComment
 		}
 

--- a/map.go
+++ b/map.go
@@ -77,15 +77,15 @@ func mapChecker(pass *analysis.Pass, cfg mapConfig, generated boolCache, comment
 			}
 		}
 
-		directives := parseDirectiveSet(relatedComments)
+		directives := parseDirectives(relatedComments)
 
-		if !cfg.explicit && directives.hasDirective(ignoreDirective) {
+		if !cfg.explicit && directives.has(ignoreDirective) {
 			// Skip checking of this map literal due to ignore
 			// comment. Still return true because there may be nested
 			// map literals that are not to be ignored.
 			return true, resultIgnoreComment
 		}
-		if cfg.explicit && !directives.hasDirective(enforceDirective) {
+		if cfg.explicit && !directives.has(enforceDirective) {
 			return true, resultNoEnforceComment
 		}
 

--- a/switch.go
+++ b/switch.go
@@ -106,7 +106,7 @@ func switchChecker(pass *analysis.Pass, cfg switchConfig, generated boolCache, c
 		}
 
 		if sw.Tag == nil {
-			return true, resultNoSwitchTag // never possible for valid Go program?
+			return true, resultNoSwitchTag
 		}
 
 		t := pass.TypesInfo.Types[sw.Tag]

--- a/switch.go
+++ b/switch.go
@@ -82,24 +82,24 @@ func switchChecker(pass *analysis.Pass, cfg switchConfig, generated boolCache, c
 		sw := n.(*ast.SwitchStmt)
 
 		switchComments := comments.get(pass.Fset, file)[sw]
-		uDirectives := parseDirectiveSet(switchComments)
+		uDirectives := parseDirectives(switchComments)
 
-		if !cfg.explicit && uDirectives.hasDirective(ignoreDirective) {
+		if !cfg.explicit && uDirectives.has(ignoreDirective) {
 			// Skip checking of this switch statement due to ignore
 			// comment. Still return true because there may be nested
 			// switch statements that are not to be ignored.
 			return true, resultIgnoreComment
 		}
-		if cfg.explicit && !uDirectives.hasDirective(enforceDirective) {
+		if cfg.explicit && !uDirectives.has(enforceDirective) {
 			// Skip checking of this switch statement due to missing
 			// enforce comment.
 			return true, resultNoEnforceComment
 		}
 		requireDefaultCase := cfg.defaultCaseRequired
-		if uDirectives.hasDirective(ignoreDefaultCaseRequiredDirective) {
+		if uDirectives.has(ignoreDefaultCaseRequiredDirective) {
 			requireDefaultCase = false
 		}
-		if uDirectives.hasDirective(enforceDefaultCaseRequiredDirective) {
+		if uDirectives.has(enforceDefaultCaseRequiredDirective) {
 			// We have "if" instead of "else if" here in case of conflicting ignore/enforce directives.
 			// In that case, because this is second, we will default to enforcing.
 			requireDefaultCase = true

--- a/switch.go
+++ b/switch.go
@@ -5,7 +5,6 @@ import (
 	"go/ast"
 	"go/types"
 	"regexp"
-	"strings"
 
 	"golang.org/x/tools/go/analysis"
 )
@@ -58,31 +57,6 @@ type switchConfig struct {
 	checkGenerated             bool
 	ignoreConstant             *regexp.Regexp // can be nil
 	ignoreType                 *regexp.Regexp // can be nil
-}
-
-// There are few possibilities, and often none, so we use a possibly-nil slice
-func userDirectives(comments []*ast.CommentGroup) []string {
-	var directives []string
-	for _, c := range comments {
-		for _, cc := range c.List {
-			// The order matters here: we always want to check the longest first.
-			for _, d := range []string{
-				enforceDefaultCaseRequiredComment,
-				ignoreDefaultCaseRequiredComment,
-				enforceComment,
-				ignoreComment,
-			} {
-				if strings.HasPrefix(cc.Text, d) {
-					directives = append(directives, d)
-					// The break here is important: once we associate a comment
-					// with a particular (longest-possible) directive, we don't want
-					// to map to another!
-					break
-				}
-			}
-		}
-	}
-	return directives
 }
 
 // switchChecker returns a node visitor that checks exhaustiveness of

--- a/testdata/src/default-case-required/default-not-required/default_not_required.go
+++ b/testdata/src/default-case-required/default-not-required/default_not_required.go
@@ -1,10 +1,11 @@
 package notrequired
 
-import "default-case-required"
+import dcr "default-case-required"
 
 func _a(t dcr.T) {
 	// No diagnostic because neither fDefaultCaseRequired is true
 	// nor the enforcement comment is present.
+	//exhaustive:enforce-default-case-required-typo this invalid directive should be ignored
 	switch t {
 	case dcr.A:
 	case dcr.B:

--- a/testdata/src/default-case-required/default-not-required/default_not_required.go
+++ b/testdata/src/default-case-required/default-not-required/default_not_required.go
@@ -5,7 +5,6 @@ import dcr "default-case-required"
 func _a(t dcr.T) {
 	// No diagnostic because neither fDefaultCaseRequired is true
 	// nor the enforcement comment is present.
-	//exhaustive:enforce-default-case-required-typo this invalid directive should be ignored
 	switch t {
 	case dcr.A:
 	case dcr.B:
@@ -21,7 +20,6 @@ func _b(t dcr.T) {
 }
 
 func _c(t dcr.T) {
-	//exhaustive:ignore-default-case-required this comment is discarded in facvor of the enforcement
 	//exhaustive:enforce-default-case-required this is a comment showing that we can turn it on for select switches
 	switch t { // want "^missing default case in switch of type dcr.T$"
 	case dcr.A:
@@ -31,7 +29,6 @@ func _c(t dcr.T) {
 
 func _d(t dcr.T) {
 	//exhaustive:enforce-default-case-required this is a comment showing that we can turn it on for select switches
-	//exhaustive:ignore-default-case-required this comment is discarded in facvor of the enforcement
 	switch t { // want "^missing default case in switch of type dcr.T$"
 	case dcr.A:
 	case dcr.B:
@@ -59,5 +56,15 @@ func _f() {
 	//exhaustive:enforce-default-case-required
 	switch {
 	case x == 0:
+	}
+}
+
+func _g(t dcr.T) {
+	//exhaustive:ignore-default-case-required
+	//exhaustive:enforce-default-case-required
+	switch t { // want "^failed to parse directives: conflicting directives \"ignore-default-case-required\" and \"enforce-default-case-required\"$"
+	case dcr.A:
+	case dcr.B:
+	default:
 	}
 }

--- a/testdata/src/default-case-required/default-required/default_required.go
+++ b/testdata/src/default-case-required/default-required/default_required.go
@@ -4,7 +4,6 @@ import dcr "default-case-required"
 
 func _a(t dcr.T) {
 	// expect a diagnostic when fDefaultCaseRequired is true.
-	//exhaustive:ignore-default-case-required-typo This invalid directive should be ignored
 	switch t { // want "^missing default case in switch of type dcr.T$"
 	case dcr.A:
 	case dcr.B:
@@ -13,7 +12,6 @@ func _a(t dcr.T) {
 
 func _b(t dcr.T) {
 	//exhaustive:ignore-default-case-required this is a comment showing that we can turn it off for select switches
-	//exhaustive:enforce-default-case-required-typo This invalid directive should be ignored
 	switch t {
 	case dcr.A:
 	case dcr.B:
@@ -21,7 +19,6 @@ func _b(t dcr.T) {
 }
 
 func _c(t dcr.T) {
-	//exhaustive:ignore-default-case-required this comment is discarded in facvor of the enforcement
 	//exhaustive:enforce-default-case-required this helps override the above
 	switch t { // want "^missing default case in switch of type dcr.T$"
 	case dcr.A:
@@ -48,5 +45,15 @@ func _e() {
 
 	switch {
 	case x == 0:
+	}
+}
+
+func _f(t dcr.T) {
+	//exhaustive:enforce-default-case-required
+	//exhaustive:ignore-default-case-required
+	switch t { // want "^failed to parse directives: conflicting directives \"ignore-default-case-required\" and \"enforce-default-case-required\"$"
+	case dcr.A:
+	case dcr.B:
+	default:
 	}
 }

--- a/testdata/src/default-case-required/default-required/default_required.go
+++ b/testdata/src/default-case-required/default-required/default_required.go
@@ -1,9 +1,10 @@
 package required
 
-import "default-case-required"
+import dcr "default-case-required"
 
 func _a(t dcr.T) {
 	// expect a diagnostic when fDefaultCaseRequired is true.
+	//exhaustive:ignore-default-case-required-typo This invalid directive should be ignored
 	switch t { // want "^missing default case in switch of type dcr.T$"
 	case dcr.A:
 	case dcr.B:
@@ -12,6 +13,7 @@ func _a(t dcr.T) {
 
 func _b(t dcr.T) {
 	//exhaustive:ignore-default-case-required this is a comment showing that we can turn it off for select switches
+	//exhaustive:enforce-default-case-required-typo This invalid directive should be ignored
 	switch t {
 	case dcr.A:
 	case dcr.B:

--- a/testdata/src/default-signifies-exhaustive/default-absent/default_absent.go
+++ b/testdata/src/default-signifies-exhaustive/default-absent/default_absent.go
@@ -1,9 +1,18 @@
 package absent
 
-import "default-signifies-exhaustive"
+import dse "default-signifies-exhaustive"
 
 func _a(t dse.T) {
 	switch t { // want "^missing cases in switch of type dse.T: dse.B$"
 	case dse.A:
+	}
+}
+
+func _b(t dse.T) {
+	//exhaustive:ignore
+	//exhaustive:enforce
+	switch t { // want "^failed to parse directives: conflicting directives \"ignore\" and \"enforce\"$"
+	case dse.A:
+	case dse.B:
 	}
 }

--- a/testdata/src/default-signifies-exhaustive/default-present/default_present.go
+++ b/testdata/src/default-signifies-exhaustive/default-present/default_present.go
@@ -1,6 +1,6 @@
 package present
 
-import "default-signifies-exhaustive"
+import dse "default-signifies-exhaustive"
 
 func _a(t dse.T) {
 	// expect no diagnostics, since default case is present,
@@ -9,5 +9,14 @@ func _a(t dse.T) {
 	switch t {
 	case dse.A:
 	default:
+	}
+}
+
+func _b(t dse.T) {
+	//exhaustive:enforce
+	//exhaustive:ignore
+	switch t { // want "^failed to parse directives: conflicting directives \"ignore\" and \"enforce\"$"
+	case dse.A:
+	case dse.B:
 	}
 }

--- a/testdata/src/enforce-comment/enforce_comment_map.go
+++ b/testdata/src/enforce-comment/enforce_comment_map.go
@@ -323,3 +323,10 @@ func localVarDeclaration() {
 		})
 	)
 }
+
+func invalidDirectiveMap() {
+	//exhaustive:enfocre
+	var _ = map[Direction]int{ // want "^failed to parse directives: invalid directive \"enfocre\"$"
+		N: 1,
+	}
+}

--- a/testdata/src/enforce-comment/enforce_comment_switch.go
+++ b/testdata/src/enforce-comment/enforce_comment_switch.go
@@ -82,3 +82,13 @@ func _reverse_nested() {
 		}
 	}
 }
+
+func invalidDirectiveSwitch() {
+	var d Direction
+
+	//exhaustive:ingore
+	switch d { // want "^failed to parse directives: invalid directive \"ingore\"$"
+	case N:
+	}
+
+}

--- a/testdata/src/general/x/directive.go
+++ b/testdata/src/general/x/directive.go
@@ -1,0 +1,28 @@
+package x
+
+func _() {
+	var d Direction
+
+	// This comment should not produce an diagnostic (note unknown prefix "exhauster:"
+	//instead of "exhaustive:".
+	//exhauster:foo
+	switch d {
+	case N:
+	case S:
+	case W:
+	case E:
+	case directionInvalid:
+	default:
+	}
+
+	// This comment should not produce an diagnostic (note unknown prefix "exhauster:"
+	//instead of "exhaustive:".
+	//exhauster:foo
+	_ = map[Direction]int{
+		N:                1,
+		S:                2,
+		W:                3,
+		E:                4,
+		directionInvalid: 0,
+	}
+}


### PR DESCRIPTION
Add `directiveSet` bitset data structure and `directive` enum with stricter parsing to not recognize comments like `//exhaustive:enforce-none` as valid directives. Also return errors on invalid directives or combinations thereof.

Resolves #70, #49 