### PR TITLE
Allow `//exhaustive:ignore` on potential enums

### DIFF
--- a/comment.go
+++ b/comment.go
@@ -29,6 +29,9 @@ type directiveSet int64
 func parseDirectives(commentGroups []*ast.CommentGroup) (directiveSet, error) {
 	var out directiveSet
 	for _, commentGroup := range commentGroups {
+		if commentGroup == nil {
+			continue
+		}
 		for _, comment := range commentGroup.List {
 			commentLine := comment.Text
 			if !strings.HasPrefix(commentLine, exhaustiveComment) {

--- a/enum.go
+++ b/enum.go
@@ -75,14 +75,14 @@ func findEnums(pass *analysis.Pass, pkgScopeOnly bool, pkg *types.Package, inspe
 			return
 		}
 
-		if isIgnoreDecl(pass, gen.Doc) {
+		if hasIgnoreDecl(pass, gen.Doc) {
 			return
 		}
 
 		for _, s := range gen.Specs {
 			s := s.(*ast.ValueSpec)
-			if isIgnoreDecl(pass, s.Doc) {
-				return
+			if hasIgnoreDecl(pass, s.Doc) {
+				continue
 			}
 
 			for _, name := range s.Names {
@@ -167,12 +167,12 @@ func findIgnoredTypes(pass *analysis.Pass, inspect *inspector.Inspector, info *t
 			return
 		}
 
-		doIgnoreDecl := isIgnoreDecl(pass, gen.Doc)
+		doIgnoreDecl := hasIgnoreDecl(pass, gen.Doc)
 
 		for _, s := range gen.Specs {
 			t := s.(*ast.TypeSpec)
 
-			doIgnoreSpec := doIgnoreDecl || isIgnoreDecl(pass, t.Doc)
+			doIgnoreSpec := doIgnoreDecl || hasIgnoreDecl(pass, t.Doc)
 			if !doIgnoreSpec {
 				continue
 			}
@@ -201,7 +201,7 @@ func validBasic(basic *types.Basic) bool {
 	return false
 }
 
-func isIgnoreDecl(pass *analysis.Pass, doc *ast.CommentGroup) bool {
+func hasIgnoreDecl(pass *analysis.Pass, doc *ast.CommentGroup) bool {
 	dirs, err := parseDirectives([]*ast.CommentGroup{doc})
 	if err != nil {
 		pass.Report(makeInvalidDirectiveDiagnostic(doc, err))

--- a/enum.go
+++ b/enum.go
@@ -67,24 +67,30 @@ func (em *enumMembers) factString() string {
 func findEnums(pass *analysis.Pass, pkgScopeOnly bool, pkg *types.Package, inspect *inspector.Inspector, info *types.Info) map[enumType]enumMembers {
 	result := make(map[enumType]enumMembers)
 
+	ignoredTypes := findIgnoredTypes(pass, inspect, info)
+
 	inspect.Preorder([]ast.Node{&ast.GenDecl{}}, func(n ast.Node) {
 		gen := n.(*ast.GenDecl)
 		if gen.Tok != token.CONST {
 			return
 		}
 
-		dirs, err := parseDirectives([]*ast.CommentGroup{gen.Doc})
-		if err != nil {
-			pass.Report(makeInvalidDirectiveDiagnostic(gen, err))
-			return
-		}
-
-		if dirs.has(ignoreDirective) {
+		if isIgnoreDecl(pass, gen.Doc) {
 			return
 		}
 
 		for _, s := range gen.Specs {
-			for _, name := range s.(*ast.ValueSpec).Names {
+			s := s.(*ast.ValueSpec)
+			if isIgnoreDecl(pass, s.Doc) {
+				return
+			}
+
+			for _, name := range s.Names {
+
+				if _, ignored := ignoredTypes[info.Defs[name].Type()]; ignored {
+					continue
+				}
+
 				enumTyp, memberName, val, ok := possibleEnumMember(name, info)
 				if !ok {
 					continue
@@ -152,6 +158,32 @@ func possibleEnumMember(constName *ast.Ident, info *types.Info) (et enumType, na
 	return enumType{tn}, obj.Name(), determineConstVal(constName, info), true
 }
 
+func findIgnoredTypes(pass *analysis.Pass, inspect *inspector.Inspector, info *types.Info) map[types.Type]struct{} {
+	ignoredTypes := map[types.Type]struct{}{}
+
+	inspect.Preorder([]ast.Node{&ast.GenDecl{}}, func(n ast.Node) {
+		gen := n.(*ast.GenDecl)
+		if gen.Tok != token.TYPE {
+			return
+		}
+
+		doIgnoreDecl := isIgnoreDecl(pass, gen.Doc)
+
+		for _, s := range gen.Specs {
+			t := s.(*ast.TypeSpec)
+
+			doIgnoreSpec := doIgnoreDecl || isIgnoreDecl(pass, t.Doc)
+			if !doIgnoreSpec {
+				continue
+			}
+
+			ignoredTypes[info.Defs[t.Name].Type()] = struct{}{}
+		}
+	})
+
+	return ignoredTypes
+}
+
 func determineConstVal(name *ast.Ident, info *types.Info) constantValue {
 	c := info.ObjectOf(name).(*types.Const)
 	return constantValue(c.Val().ExactString())
@@ -167,6 +199,15 @@ func validBasic(basic *types.Basic) bool {
 		return true
 	}
 	return false
+}
+
+func isIgnoreDecl(pass *analysis.Pass, doc *ast.CommentGroup) bool {
+	dirs, err := parseDirectives([]*ast.CommentGroup{doc})
+	if err != nil {
+		pass.Report(makeInvalidDirectiveDiagnostic(doc, err))
+		return false
+	}
+	return dirs.has(ignoreDirective)
 }
 
 // validNamedBasic returns whether the type t is a named type whose underlying

--- a/enum_test.go
+++ b/enum_test.go
@@ -414,6 +414,18 @@ func checkEnums(t *testing.T, got []checkEnum, pkgOnly bool) {
 				`1`: {"DeclTypeNotIgnoredValue"},
 			},
 		}},
+		{"DeclTypePartialIgnore", enumMembers{
+			[]string{"DeclTypePartialIgnoreNotIgnored"},
+			map[string]token.Pos{
+				"DeclTypePartialIgnoreNotIgnored": 0,
+			},
+			map[string]constantValue{
+				"DeclTypePartialIgnoreNotIgnored": `2`,
+			},
+			map[constantValue][]string{
+				`2`: {"DeclTypePartialIgnoreNotIgnored"},
+			},
+		}},
 	}
 
 	for _, c := range wantPkg {

--- a/enum_test.go
+++ b/enum_test.go
@@ -96,7 +96,7 @@ func TestFindEnums(t *testing.T) {
 
 	for _, pkgOnly := range [...]bool{false, true} {
 		t.Run(fmt.Sprint("pkgOnly", pkgOnly), func(t *testing.T) {
-			result := findEnums(pkgOnly, testdataEnumPkg.Types, inspect, testdataEnumPkg.TypesInfo)
+			result := findEnums(nil, pkgOnly, testdataEnumPkg.Types, inspect, testdataEnumPkg.TypesInfo)
 			checkEnums(t, transform(result), pkgOnly)
 		})
 	}
@@ -364,6 +364,30 @@ func checkEnums(t *testing.T, got []checkEnum, pkgOnly bool) {
 			map[constantValue][]string{
 				`0`: {"Float64A"},
 				`1`: {"Float64B"},
+			},
+		}},
+		{"DeclGroupIgnoredEnum", enumMembers{
+			[]string{"DeclGroupIgnoredMamberC"},
+			map[string]token.Pos{
+				"DeclGroupIgnoredMamberC": 0,
+			},
+			map[string]constantValue{
+				"DeclGroupIgnoredMamberC": `3`,
+			},
+			map[constantValue][]string{
+				`3`: {"DeclGroupIgnoredMamberC"},
+			},
+		}},
+		{"DeclIgnoredEnum", enumMembers{
+			[]string{"DeclIgnoredMamberB"},
+			map[string]token.Pos{
+				"DeclIgnoredMamberB": 0,
+			},
+			map[string]constantValue{
+				"DeclIgnoredMamberB": `2`,
+			},
+			map[constantValue][]string{
+				`2`: {"DeclIgnoredMamberB"},
 			},
 		}},
 	}

--- a/enum_test.go
+++ b/enum_test.go
@@ -367,27 +367,51 @@ func checkEnums(t *testing.T, got []checkEnum, pkgOnly bool) {
 			},
 		}},
 		{"DeclGroupIgnoredEnum", enumMembers{
-			[]string{"DeclGroupIgnoredMamberC"},
+			[]string{"DeclGroupIgnoredMemberC"},
 			map[string]token.Pos{
-				"DeclGroupIgnoredMamberC": 0,
+				"DeclGroupIgnoredMemberC": 0,
 			},
 			map[string]constantValue{
-				"DeclGroupIgnoredMamberC": `3`,
+				"DeclGroupIgnoredMemberC": `3`,
 			},
 			map[constantValue][]string{
-				`3`: {"DeclGroupIgnoredMamberC"},
+				`3`: {"DeclGroupIgnoredMemberC"},
 			},
 		}},
 		{"DeclIgnoredEnum", enumMembers{
-			[]string{"DeclIgnoredMamberB"},
+			[]string{"DeclIgnoredMemberB"},
 			map[string]token.Pos{
-				"DeclIgnoredMamberB": 0,
+				"DeclIgnoredMemberB": 0,
 			},
 			map[string]constantValue{
-				"DeclIgnoredMamberB": `2`,
+				"DeclIgnoredMemberB": `2`,
 			},
 			map[constantValue][]string{
-				`2`: {"DeclIgnoredMamberB"},
+				`2`: {"DeclIgnoredMemberB"},
+			},
+		}},
+		{"DeclTypeInnerNotIgnore", enumMembers{
+			[]string{"DeclTypeInnerNotIgnoreMember"},
+			map[string]token.Pos{
+				"DeclTypeInnerNotIgnoreMember": 0,
+			},
+			map[string]constantValue{
+				"DeclTypeInnerNotIgnoreMember": `5`,
+			},
+			map[constantValue][]string{
+				`5`: {"DeclTypeInnerNotIgnoreMember"},
+			},
+		}},
+		{"DeclTypeIgnoredValue", enumMembers{
+			[]string{"DeclTypeNotIgnoredValue"},
+			map[string]token.Pos{
+				"DeclTypeNotIgnoredValue": 0,
+			},
+			map[string]constantValue{
+				"DeclTypeNotIgnoredValue": `1`,
+			},
+			map[constantValue][]string{
+				`1`: {"DeclTypeNotIgnoredValue"},
 			},
 		}},
 	}

--- a/exhaustive.go
+++ b/exhaustive.go
@@ -108,7 +108,7 @@ var Analyzer = &analysis.Analyzer{
 func run(pass *analysis.Pass) (interface{}, error) {
 	inspect := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
 
-	for typ, members := range findEnums(fPackageScopeOnly, pass.Pkg, inspect, pass.TypesInfo) {
+	for typ, members := range findEnums(pass, fPackageScopeOnly, pass.Pkg, inspect, pass.TypesInfo) {
 		exportFact(pass, typ, members)
 	}
 

--- a/testdata/src/enum/enum.go
+++ b/testdata/src/enum/enum.go
@@ -131,3 +131,11 @@ const (
 	//exhaustive:ignore
 	DeclTypeIsIgnoredValue DeclTypeIgnoredValue = 2
 )
+
+type DeclTypePartialIgnore int // want DeclTypePartialIgnore:"^DeclTypePartialIgnoreNotIgnored$"
+
+const (
+	//exhaustive:ignore
+	DeclTypePartialIgnoreIgnored    DeclTypePartialIgnore = 1
+	DeclTypePartialIgnoreNotIgnored DeclTypePartialIgnore = 2
+)

--- a/testdata/src/enum/enum.go
+++ b/testdata/src/enum/enum.go
@@ -87,19 +87,47 @@ const (
 
 func (WithMethod) String() string { return "whatever" }
 
-type DeclGroupIgnoredEnum int // want DeclGroupIgnoredEnum:"^DeclGroupIgnoredMamberC$"
+type DeclGroupIgnoredEnum int // want DeclGroupIgnoredEnum:"^DeclGroupIgnoredMemberC$"
 
 //exhaustive:ignore
 const (
-	DeclGroupIgnoredMamberA DeclGroupIgnoredEnum = 1
-	DeclGroupIgnoredMamberB DeclGroupIgnoredEnum = 2
+	DeclGroupIgnoredMemberA DeclGroupIgnoredEnum = 1
+	DeclGroupIgnoredMemberB DeclGroupIgnoredEnum = 2
 )
 
-const DeclGroupIgnoredMamberC DeclGroupIgnoredEnum = 3
+const DeclGroupIgnoredMemberC DeclGroupIgnoredEnum = 3
 
-type DeclIgnoredEnum int // want DeclIgnoredEnum:"^DeclIgnoredMamberB$"
+type DeclIgnoredEnum int // want DeclIgnoredEnum:"^DeclIgnoredMemberB$"
 
 //exhaustive:ignore
-const DeclIgnoredMamberA DeclIgnoredEnum = 1
+const DeclIgnoredMemberA DeclIgnoredEnum = 1
 
-const DeclIgnoredMamberB DeclIgnoredEnum = 2
+const DeclIgnoredMemberB DeclIgnoredEnum = 2
+
+//exhaustive:ignore
+type DeclTypeIgnoredEnum int
+
+const (
+	DeclTypeIgnoredMemberA DeclTypeIgnoredEnum = 1
+	DeclTypeIgnoredMemberB DeclTypeIgnoredEnum = 2
+)
+
+type (
+	//exhaustive:ignore
+	DeclTypeInnerIgnore    int
+	DeclTypeInnerNotIgnore int // want DeclTypeInnerNotIgnore:"^DeclTypeInnerNotIgnoreMember$"
+)
+
+const (
+	DeclTypeInnerIgnoreMemberA   DeclTypeInnerIgnore    = 3
+	DeclTypeInnerIgnoreMemberB   DeclTypeInnerIgnore    = 4
+	DeclTypeInnerNotIgnoreMember DeclTypeInnerNotIgnore = 5
+)
+
+type DeclTypeIgnoredValue int // want DeclTypeIgnoredValue:"^DeclTypeNotIgnoredValue$"
+
+const (
+	DeclTypeNotIgnoredValue DeclTypeIgnoredValue = 1
+	//exhaustive:ignore
+	DeclTypeIsIgnoredValue DeclTypeIgnoredValue = 2
+)

--- a/testdata/src/enum/enum.go
+++ b/testdata/src/enum/enum.go
@@ -86,3 +86,20 @@ const (
 )
 
 func (WithMethod) String() string { return "whatever" }
+
+type DeclGroupIgnoredEnum int // want DeclGroupIgnoredEnum:"^DeclGroupIgnoredMamberC$"
+
+//exhaustive:ignore
+const (
+	DeclGroupIgnoredMamberA DeclGroupIgnoredEnum = 1
+	DeclGroupIgnoredMamberB DeclGroupIgnoredEnum = 2
+)
+
+const DeclGroupIgnoredMamberC DeclGroupIgnoredEnum = 3
+
+type DeclIgnoredEnum int // want DeclIgnoredEnum:"^DeclIgnoredMamberB$"
+
+//exhaustive:ignore
+const DeclIgnoredMamberA DeclIgnoredEnum = 1
+
+const DeclIgnoredMamberB DeclIgnoredEnum = 2


### PR DESCRIPTION
Fixes #76 

This PR enables these examples:

Ignoring declared constants (d9dc665917671737c1b855f7d83e4c659de4e9d2):
```go
type DeclIgnoredEnum int // want no enum detected

//exhaustive:ignore
const (
	DeclIgnoredMamberA DeclIgnoredEnum = 1
	DeclIgnoredMamberB DeclIgnoredEnum = 2
)

//exhaustive:ignore
const DeclIgnoredMamberC DeclIgnoredEnum = 3
```

Ignoring declared types (272c2ab35889b34dde75d76480fac7ccc048839f):
```go
//exhaustive:ignore
type DeclTypeIgnoredEnum int

const (
	DeclTypeIgnoredMamberA DeclTypeIgnoredEnum = 1
	DeclTypeIgnoredMamberB DeclTypeIgnoredEnum = 2
)
```

Both commits are under test.