### PR TITLE
avoid panic in tests

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -38,7 +38,7 @@ func TestChecklist(t *testing.T) {
 			"5": {"C"},
 		},
 	}
-	checkEnumMembersLiteral("TestChecklist", em)
+	checkEnumMembersLiteral(t, "TestChecklist", em)
 
 	checkRemaining := func(t *testing.T, h checklist, want map[string]struct{}) {
 		t.Helper()
@@ -225,7 +225,7 @@ func TestChecklist(t *testing.T) {
 				"5": {"C"},
 			},
 		}
-		checkEnumMembersLiteral("TestChecklist blank identifier", em)
+		checkEnumMembersLiteral(t, "TestChecklist blank identifier", em)
 
 		var c checklist
 		c.add(et, em, true)
@@ -272,7 +272,7 @@ func TestChecklist(t *testing.T) {
 				"42": {"lowercase"},
 			},
 		}
-		checkEnumMembersLiteral("TestChecklist lowercase", em)
+		checkEnumMembersLiteral(t, "TestChecklist lowercase", em)
 
 		t.Run("include", func(t *testing.T) {
 			var c checklist

--- a/enum_test.go
+++ b/enum_test.go
@@ -13,19 +13,19 @@ import (
 
 // checkEnumMembersLiteral checks that an enumMembers literal is correctly
 // defined in tests.
-func checkEnumMembersLiteral(id string, v enumMembers) {
+func checkEnumMembersLiteral(t *testing.T, id string, v enumMembers) {
 	var count int
 	for _, names := range v.ValueToNames {
 		count += len(names)
 	}
 	if len(v.Names) != len(v.NameToPos) {
-		panic(fmt.Sprintf("%s: wrong lengths: %d != %d (test definition bug)", id, len(v.Names), len(v.NameToPos)))
+		t.Fatalf("%s: wrong lengths: %d != %d (test definition bug)", id, len(v.Names), len(v.NameToPos))
 	}
 	if len(v.Names) != len(v.NameToValue) {
-		panic(fmt.Sprintf("%s: wrong lengths: %d != %d (test definition bug)", id, len(v.Names), len(v.NameToValue)))
+		t.Fatalf("%s: wrong lengths: %d != %d (test definition bug)", id, len(v.Names), len(v.NameToValue))
 	}
 	if len(v.Names) != count {
-		panic(fmt.Sprintf("%s: wrong lengths: %d != %d (test definition bug)", id, len(v.Names), count))
+		t.Fatalf("%s: wrong lengths: %d != %d (test definition bug)", id, len(v.Names), count)
 	}
 }
 
@@ -88,7 +88,7 @@ func TestFindEnums(t *testing.T) {
 		cfg := &packages.Config{Mode: packages.NeedTypesInfo | packages.NeedTypes | packages.NeedSyntax}
 		pkgs, err := packages.Load(cfg, "./testdata/src/enum")
 		if err != nil {
-			panic(err)
+			t.Fatal(err)
 		}
 		return pkgs[0]
 	}()
@@ -429,7 +429,7 @@ func checkEnums(t *testing.T, got []checkEnum, pkgOnly bool) {
 	}
 
 	for _, c := range wantPkg {
-		checkEnumMembersLiteral(c.typeName, c.members)
+		checkEnumMembersLiteral(t, c.typeName, c.members)
 	}
 
 	wantInner := []checkEnum{
@@ -486,7 +486,7 @@ func checkEnums(t *testing.T, got []checkEnum, pkgOnly bool) {
 	}
 
 	for _, c := range wantInner {
-		checkEnumMembersLiteral(c.typeName, c.members)
+		checkEnumMembersLiteral(t, c.typeName, c.members)
 	}
 
 	want := append([]checkEnum{}, wantPkg...)

--- a/fact_test.go
+++ b/fact_test.go
@@ -33,7 +33,7 @@ func TestEnumMembersFact(t *testing.T) {
 				},
 			},
 		}
-		checkEnumMembersLiteral("Biome", e.Members)
+		checkEnumMembersLiteral(t, "Biome", e.Members)
 		if want := "Tundra,Savanna,Desert"; e.String() != want {
 			t.Errorf("got %v, want %v", e.String(), want)
 		}
@@ -65,7 +65,7 @@ func TestEnumMembersFact(t *testing.T) {
 				},
 			},
 		}
-		checkEnumMembersLiteral("Token", e.Members)
+		checkEnumMembersLiteral(t, "Token", e.Members)
 		if want := "_,add,sub,mul,quotient,remainder"; e.String() != want {
 			t.Errorf("got %v, want %v", e.String(), want)
 		}


### PR DESCRIPTION
[`t.Fatal`](https://pkg.go.dev/testing#T.Fatal) is specifically designed for use in tests instead of `panic`. It stops tests execution immediately.