### PR TITLE
add t.Parallel() to speed up tests

### DIFF
--- a/exhaustive_test.go
+++ b/exhaustive_test.go
@@ -11,6 +11,7 @@ func TestExhaustive(t *testing.T) {
 	runTest := func(t *testing.T, pattern string, setup ...func()) {
 		t.Helper()
 		t.Run(pattern, func(t *testing.T) {
+			t.Parallel()
 			resetFlags()
 			// default to checking switch and map for test.
 			fCheck = stringsFlag{


### PR DESCRIPTION
Fixes #75

The [`vgt`](https://github.com/roblaszczak/vgt) tool is used to analyze tests execution:

```sh
$ go test -json -count=1 ./... | vgt
```

Before:

![image](https://github.com/user-attachments/assets/ed791d01-2325-4d5b-a83e-3f1282be6f48)

After:

![image](https://github.com/user-attachments/assets/23731bdd-b153-405c-96fb-02d5e86bc95f)


See https://threedots.tech/post/go-test-parallelism/
