### PR TITLE
feature: add enforce-enum-types flag

### DIFF
--- a/common.go
+++ b/common.go
@@ -19,6 +19,23 @@ type enumTypeAndMembers struct {
 	members enumMembers
 }
 
+func enumTypeQualifiedName(et enumType) string {
+	return fmt.Sprintf("%s.%s", et.Pkg().Path(), et.TypeName.Name())
+}
+
+func filterEnforcedTypes(es []enumTypeAndMembers, enforce *regexp.Regexp) ([]enumTypeAndMembers, bool) {
+	if enforce == nil {
+		return es, len(es) > 0
+	}
+	filtered := es[:0]
+	for _, e := range es {
+		if enforce.MatchString(enumTypeQualifiedName(e.typ)) {
+			filtered = append(filtered, e)
+		}
+	}
+	return filtered, len(filtered) > 0
+}
+
 func fromNamed(pass *analysis.Pass, t *types.Named, typeparam bool) (result []enumTypeAndMembers, ok bool) {
 	if tpkg := t.Obj().Pkg(); tpkg == nil {
 		// go/types documentation says: nil for labels and
@@ -291,7 +308,7 @@ func (c *checklist) add(et enumType, em enumMembers, includeUnexported bool) {
 		if c.reMatch(c.ignoreConstantRe, fmt.Sprintf("%s.%s", et.Pkg().Path(), name)) {
 			return
 		}
-		if c.reMatch(c.ignoreTypeRe, fmt.Sprintf("%s.%s", et.Pkg().Path(), et.TypeName.Name())) {
+		if c.reMatch(c.ignoreTypeRe, enumTypeQualifiedName(et)) {
 			return
 		}
 		mem := member{

--- a/doc.go
+++ b/doc.go
@@ -138,6 +138,7 @@ Summary:
 	-default-signifies-exhaustive  bool                     false
 	-ignore-enum-members           regexp pattern           (none)
 	-ignore-enum-types             regexp pattern           (none)
+	-enforce-enum-types            regexp pattern           (none)
 	-package-scope-only            bool                     false
 
 Descriptions:
@@ -182,6 +183,11 @@ Descriptions:
 
 	-ignore-enum-types
 		Similar to -ignore-enum-members but for types.
+
+	-enforce-enum-types
+		Only check enum types whose fully qualified name (package path
+		followed by the type name) matches the specified regular expression.
+		When this flag is unset, all enum types are checked.
 
 	-package-scope-only
 		Only discover enums declared in file-level blocks. By

--- a/exhaustive.go
+++ b/exhaustive.go
@@ -22,6 +22,7 @@ func registerFlags() {
 	Analyzer.Flags.BoolVar(&fDefaultCaseRequired, DefaultCaseRequiredFlag, false, "switch statement requires default case even if exhaustive")
 	Analyzer.Flags.Var(&fIgnoreEnumMembers, IgnoreEnumMembersFlag, "ignore constants matching `regexp`")
 	Analyzer.Flags.Var(&fIgnoreEnumTypes, IgnoreEnumTypesFlag, "ignore types matching `regexp`")
+	Analyzer.Flags.Var(&fEnforceEnumTypes, EnforceEnumTypesFlag, "only check enum types matching `regexp`")
 	Analyzer.Flags.BoolVar(&fPackageScopeOnly, PackageScopeOnlyFlag, false, "only discover enums declared in file-level blocks")
 
 	var unused string
@@ -40,6 +41,7 @@ const (
 	DefaultCaseRequiredFlag        = "default-case-required"
 	IgnoreEnumMembersFlag          = "ignore-enum-members"
 	IgnoreEnumTypesFlag            = "ignore-enum-types"
+	EnforceEnumTypesFlag           = "enforce-enum-types"
 	PackageScopeOnlyFlag           = "package-scope-only"
 
 	// Deprecated flag names.
@@ -57,6 +59,7 @@ var (
 	fDefaultCaseRequired        bool
 	fIgnoreEnumMembers          regexpFlag
 	fIgnoreEnumTypes            regexpFlag
+	fEnforceEnumTypes           regexpFlag
 	fPackageScopeOnly           bool
 )
 
@@ -71,6 +74,7 @@ func resetFlags() {
 	fDefaultCaseRequired = false
 	fIgnoreEnumMembers = regexpFlag{}
 	fIgnoreEnumTypes = regexpFlag{}
+	fEnforceEnumTypes = regexpFlag{}
 	fPackageScopeOnly = false
 }
 
@@ -129,6 +133,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 				checkGenerated:             fCheckGenerated,
 				ignoreConstant:             fIgnoreEnumMembers.re,
 				ignoreType:                 fIgnoreEnumTypes.re,
+				enforceType:                fEnforceEnumTypes.re,
 			}
 			checker := switchChecker(pass, conf, generated, comments)
 			inspect.WithStack([]ast.Node{&ast.SwitchStmt{}}, toVisitor(checker))
@@ -139,6 +144,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 				checkGenerated: fCheckGenerated,
 				ignoreConstant: fIgnoreEnumMembers.re,
 				ignoreType:     fIgnoreEnumTypes.re,
+				enforceType:    fEnforceEnumTypes.re,
 			}
 			checker := mapChecker(pass, conf, generated, comments)
 			inspect.WithStack([]ast.Node{&ast.CompositeLit{}}, toVisitor(checker))

--- a/exhaustive_test.go
+++ b/exhaustive_test.go
@@ -75,6 +75,12 @@ func TestExhaustive(t *testing.T) {
 		fExplicitExhaustiveMap = true
 	})
 
+	runTest(t, "enforceenumtypes/...", func() {
+		fEnforceEnumTypes = regexpFlag{
+			regexp.MustCompile(`^enforceenumtypes\.MetricType$`),
+		}
+	})
+
 	// To satisfy exhaustiveness, it is sufficient for each unique constant
 	// value of the members to be listed, not each member by name.
 	runTest(t, "duplicate-enum-value/...")

--- a/map.go
+++ b/map.go
@@ -15,6 +15,7 @@ type mapConfig struct {
 	checkGenerated bool
 	ignoreConstant *regexp.Regexp // can be nil
 	ignoreType     *regexp.Regexp // can be nil
+	enforceType    *regexp.Regexp // can be nil
 }
 
 // mapChecker returns a node visitor that checks for exhaustiveness of
@@ -95,6 +96,12 @@ func mapChecker(pass *analysis.Pass, cfg mapConfig, generated boolCache, comment
 		es, ok := composingEnumTypes(pass, mapType.Key())
 		if !ok || len(es) == 0 {
 			return true, resultEnumTypes
+		}
+
+		var okFilter bool
+		es, okFilter = filterEnforcedTypes(es, cfg.enforceType)
+		if !okFilter {
+			return true, resultTypeNotEnforced
 		}
 
 		var checkl checklist

--- a/switch.go
+++ b/switch.go
@@ -47,6 +47,7 @@ const (
 	resultMissingDefaultCase   = "missing required default case"
 	resultReportedDiagnostic   = "reported diagnostic"
 	resultEnumTypes            = "invalid or empty composing enum types"
+	resultTypeNotEnforced      = "enum type not enforced"
 )
 
 // switchConfig is configuration for switchChecker.
@@ -57,6 +58,7 @@ type switchConfig struct {
 	checkGenerated             bool
 	ignoreConstant             *regexp.Regexp // can be nil
 	ignoreType                 *regexp.Regexp // can be nil
+	enforceType                *regexp.Regexp // can be nil
 }
 
 // switchChecker returns a node visitor that checks exhaustiveness of
@@ -120,6 +122,12 @@ func switchChecker(pass *analysis.Pass, cfg switchConfig, generated boolCache, c
 		es, ok := composingEnumTypes(pass, t.Type)
 		if !ok || len(es) == 0 {
 			return true, resultEnumTypes
+		}
+
+		var okFilter bool
+		es, okFilter = filterEnforcedTypes(es, cfg.enforceType)
+		if !okFilter {
+			return true, resultTypeNotEnforced
 		}
 
 		var checkl checklist

--- a/testdata/src/enforceenumtypes/enforceenumtypes.go
+++ b/testdata/src/enforceenumtypes/enforceenumtypes.go
@@ -1,0 +1,40 @@
+package enforceenumtypes
+
+type MetricType int // want MetricType:"^MetricTypeUnset,MetricTypeGauge,MetricTypeSum$"
+
+const (
+	MetricTypeUnset MetricType = iota
+	MetricTypeGauge
+	MetricTypeSum
+)
+
+type NotConcerned int // want NotConcerned:"^NotConcernedOne,NotConcernedTwo$"
+
+const (
+	NotConcernedOne NotConcerned = iota
+	NotConcernedTwo
+)
+
+func CheckMetricSwitch(v MetricType) {
+	switch v { // want "^missing cases in switch of type enforceenumtypes.MetricType: enforceenumtypes.MetricTypeGauge, enforceenumtypes.MetricTypeSum$"
+	case MetricTypeUnset:
+	}
+}
+
+func CheckOtherSwitch(v NotConcerned) {
+	switch v {
+	case NotConcernedOne:
+	}
+}
+
+func CheckMetricMap() {
+	_ = map[MetricType]int{ // want "^missing keys in map of key type enforceenumtypes.MetricType: enforceenumtypes.MetricTypeGauge, enforceenumtypes.MetricTypeSum$"
+		MetricTypeUnset: 0,
+	}
+}
+
+func CheckOtherMap() {
+	_ = map[NotConcerned]int{
+		NotConcernedOne: 0,
+	}
+}


### PR DESCRIPTION
Adds a flag `enforce-enum-types` when, if set, only checks specified enum types. Like `ignore-enum-types` and `ignore-enum-members` it takes a regular expression used to match fully-qualified type names.

Closes #65.