### PR TITLE
Add package-level //exhaustive:enforce and //exhaustive:ignore directives

### DIFF
--- a/comment.go
+++ b/comment.go
@@ -77,3 +77,40 @@ func (d directiveSet) validate() error {
 func fileCommentMap(fset *token.FileSet, file *ast.File) ast.CommentMap {
 	return ast.NewCommentMap(fset, file, file.Comments)
 }
+
+// packageDirective represents the package-level directive state.
+type packageDirective int
+
+const (
+	packageDirectiveNone    packageDirective = iota
+	packageDirectiveEnforce                  // //exhaustive:enforce on package clause
+	packageDirectiveIgnore                   // //exhaustive:ignore on package clause
+)
+
+// packageLevelDirective returns the package-level directive found on
+// package clauses across all files in the package. A directive on any
+// file's package clause applies to the entire package.
+func packageLevelDirective(files []*ast.File) (packageDirective, error) {
+	var out directiveSet
+	for _, file := range files {
+		if file.Doc == nil {
+			continue
+		}
+		d, err := parseDirectives([]*ast.CommentGroup{file.Doc})
+		if err != nil {
+			return packageDirectiveNone, err
+		}
+		out |= d
+	}
+	if err := out.validate(); err != nil {
+		return packageDirectiveNone, err
+	}
+	switch {
+	case out.has(enforceDirective):
+		return packageDirectiveEnforce, nil
+	case out.has(ignoreDirective):
+		return packageDirectiveIgnore, nil
+	default:
+		return packageDirectiveNone, nil
+	}
+}

--- a/doc.go
+++ b/doc.go
@@ -188,6 +188,35 @@ Descriptions:
 		default, the analyzer discovers enums defined in all
 		blocks.
 
+# Package-level directives
+
+The "//exhaustive:enforce" and "//exhaustive:ignore" directives can be placed
+on a package clause to apply to all switch statements and map literals in the
+package.
+
+To enforce exhaustive checking for an entire package, add "//exhaustive:enforce"
+to the package clause in any file in the package:
+
+	//exhaustive:enforce
+	package mypkg
+
+This is particularly useful in combination with the -explicit-exhaustive-switch
+or -explicit-exhaustive-map flags: it allows entire packages to opt in to
+exhaustive checking without annotating every switch or map individually.
+Individual switch statements or map literals within an enforced package can
+still be skipped using a per-statement "//exhaustive:ignore".
+
+To ignore exhaustive checking for an entire package, add "//exhaustive:ignore"
+to the package clause:
+
+	//exhaustive:ignore
+	package mypkg
+
+In non-explicit mode (the default), this skips checking for all switch
+statements and map literals in the package. Individual switch statements or
+map literals can still be checked by adding a per-statement
+"//exhaustive:enforce".
+
 # Skip analysis
 
 To skip analysis of a switch statement or a map literal, associate it with a

--- a/exhaustive.go
+++ b/exhaustive.go
@@ -115,6 +115,12 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	generated := boolCache{compute: isGeneratedFile}
 	comments := commentCache{compute: fileCommentMap}
 
+	pkgDir, pkgDirErr := packageLevelDirective(pass.Files)
+	if pkgDirErr != nil {
+		// Report the error on the first file's package clause.
+		pass.Report(makeInvalidDirectiveDiagnostic(pass.Files[0], pkgDirErr))
+	}
+
 	// NOTE: should not share the same inspect.WithStack call for different
 	// program elements: the visitor function for a program element may
 	// exit traversal early, but this shouldn't affect traversal for
@@ -129,16 +135,18 @@ func run(pass *analysis.Pass) (interface{}, error) {
 				checkGenerated:             fCheckGenerated,
 				ignoreConstant:             fIgnoreEnumMembers.re,
 				ignoreType:                 fIgnoreEnumTypes.re,
+				packageDirective:           pkgDir,
 			}
 			checker := switchChecker(pass, conf, generated, comments)
 			inspect.WithStack([]ast.Node{&ast.SwitchStmt{}}, toVisitor(checker))
 
 		case elementMap:
 			conf := mapConfig{
-				explicit:       fExplicitExhaustiveMap,
-				checkGenerated: fCheckGenerated,
-				ignoreConstant: fIgnoreEnumMembers.re,
-				ignoreType:     fIgnoreEnumTypes.re,
+				explicit:         fExplicitExhaustiveMap,
+				checkGenerated:   fCheckGenerated,
+				ignoreConstant:   fIgnoreEnumMembers.re,
+				ignoreType:       fIgnoreEnumTypes.re,
+				packageDirective: pkgDir,
 			}
 			checker := mapChecker(pass, conf, generated, comments)
 			inspect.WithStack([]ast.Node{&ast.CompositeLit{}}, toVisitor(checker))

--- a/exhaustive_test.go
+++ b/exhaustive_test.go
@@ -75,6 +75,34 @@ func TestExhaustive(t *testing.T) {
 		fExplicitExhaustiveMap = true
 	})
 
+	// Package-level enforce: //exhaustive:enforce on package clause.
+	// In explicit mode, package-level enforce activates checking for all
+	// switches/maps in the package; per-switch ignore overrides.
+	runTest(t, "package-enforce/explicit-switch/...", func() {
+		fExplicitExhaustiveSwitch = true
+		fExplicitExhaustiveMap = true
+	})
+	runTest(t, "package-enforce/explicit-map/...", func() {
+		fExplicitExhaustiveSwitch = true
+		fExplicitExhaustiveMap = true
+	})
+	// In implicit mode, package-level enforce is redundant but harmless.
+	runTest(t, "package-enforce/implicit-switch/...")
+	// Without package-level enforce, explicit mode requires per-switch enforce.
+	runTest(t, "package-enforce/no-directive/...", func() {
+		fExplicitExhaustiveSwitch = true
+		fExplicitExhaustiveMap = true
+	})
+
+	// Package-level ignore: //exhaustive:ignore on package clause.
+	// In non-explicit mode, package-level ignore skips all switches/maps
+	// in the package; per-statement enforce overrides.
+	runTest(t, "package-ignore/implicit-switch/...")
+	runTest(t, "package-ignore/implicit-map/...")
+
+	// Conflicting package-level directives should produce a diagnostic.
+	runTest(t, "package-conflict/...")
+
 	// To satisfy exhaustiveness, it is sufficient for each unique constant
 	// value of the members to be listed, not each member by name.
 	runTest(t, "duplicate-enum-value/...")

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,10 @@
 module github.com/nishanths/exhaustive
 
-go 1.18
+go 1.25.0
 
-require golang.org/x/tools v0.18.0
+require golang.org/x/tools v0.43.0
 
-require golang.org/x/mod v0.15.0 // indirect
+require (
+	golang.org/x/mod v0.34.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,8 @@
-golang.org/x/mod v0.15.0 h1:SernR4v+D55NyBH2QiEQrlBAnj1ECL6AGrA5+dPaMY8=
-golang.org/x/mod v0.15.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
-golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
-golang.org/x/tools v0.18.0 h1:k8NLag8AGHnn+PHbl7g43CtqZAwG60vZkLqgyZgIHgQ=
-golang.org/x/tools v0.18.0/go.mod h1:GL7B4CwcLLeo59yx/9UWWuNOW1n3VZ4f5axWfML7Lcg=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/mod v0.34.0 h1:xIHgNUUnW6sYkcM5Jleh05DvLOtwc6RitGHbDk4akRI=
+golang.org/x/mod v0.34.0/go.mod h1:ykgH52iCZe79kzLLMhyCUzhMci+nQj+0XkbXpNYtVjY=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/tools v0.43.0 h1:12BdW9CeB3Z+J/I/wj34VMl8X+fEXBxVR90JeMX5E7s=
+golang.org/x/tools v0.43.0/go.mod h1:uHkMso649BX2cZK6+RpuIPXS3ho2hZo4FVwfoy1vIk0=

--- a/map.go
+++ b/map.go
@@ -11,10 +11,11 @@ import (
 
 // mapConfig is configuration for mapChecker.
 type mapConfig struct {
-	explicit       bool
-	checkGenerated bool
-	ignoreConstant *regexp.Regexp // can be nil
-	ignoreType     *regexp.Regexp // can be nil
+	explicit         bool
+	checkGenerated   bool
+	ignoreConstant   *regexp.Regexp // can be nil
+	ignoreType       *regexp.Regexp // can be nil
+	packageDirective packageDirective
 }
 
 // mapChecker returns a node visitor that checks for exhaustiveness of
@@ -82,13 +83,20 @@ func mapChecker(pass *analysis.Pass, cfg mapConfig, generated boolCache, comment
 			pass.Report(makeInvalidDirectiveDiagnostic(lit, err))
 		}
 
-		if !cfg.explicit && directives.has(ignoreDirective) {
-			// Skip checking of this map literal due to ignore
-			// comment. Still return true because there may be nested
-			// map literals that are not to be ignored.
-			return true, resultIgnoreComment
+		enforced := directives.has(enforceDirective) || cfg.packageDirective == packageDirectiveEnforce
+		ignored := directives.has(ignoreDirective) || cfg.packageDirective == packageDirectiveIgnore
+
+		if ignored && !directives.has(enforceDirective) {
+			if !cfg.explicit || enforced {
+				// Skip checking of this map literal due to ignore
+				// directive (statement-level or package-level). A
+				// per-statement enforce directive overrides package-level
+				// ignore. Still return true because there may be nested
+				// map literals that are not to be ignored.
+				return true, resultIgnoreComment
+			}
 		}
-		if cfg.explicit && !directives.has(enforceDirective) {
+		if cfg.explicit && !enforced {
 			return true, resultNoEnforceComment
 		}
 

--- a/switch.go
+++ b/switch.go
@@ -57,6 +57,7 @@ type switchConfig struct {
 	checkGenerated             bool
 	ignoreConstant             *regexp.Regexp // can be nil
 	ignoreType                 *regexp.Regexp // can be nil
+	packageDirective           packageDirective
 }
 
 // switchChecker returns a node visitor that checks exhaustiveness of
@@ -87,13 +88,20 @@ func switchChecker(pass *analysis.Pass, cfg switchConfig, generated boolCache, c
 			pass.Report(makeInvalidDirectiveDiagnostic(sw, err))
 		}
 
-		if !cfg.explicit && uDirectives.has(ignoreDirective) {
-			// Skip checking of this switch statement due to ignore
-			// comment. Still return true because there may be nested
-			// switch statements that are not to be ignored.
-			return true, resultIgnoreComment
+		enforced := uDirectives.has(enforceDirective) || cfg.packageDirective == packageDirectiveEnforce
+		ignored := uDirectives.has(ignoreDirective) || cfg.packageDirective == packageDirectiveIgnore
+
+		if ignored && !uDirectives.has(enforceDirective) {
+			if !cfg.explicit || enforced {
+				// Skip checking of this switch statement due to ignore
+				// directive (statement-level or package-level). A
+				// per-statement enforce directive overrides package-level
+				// ignore. Still return true because there may be nested
+				// switch statements that are not to be ignored.
+				return true, resultIgnoreComment
+			}
 		}
-		if cfg.explicit && !uDirectives.has(enforceDirective) {
+		if cfg.explicit && !enforced {
 			// Skip checking of this switch statement due to missing
 			// enforce comment.
 			return true, resultNoEnforceComment

--- a/testdata/src/package-conflict/a.go
+++ b/testdata/src/package-conflict/a.go
@@ -1,0 +1,11 @@
+//exhaustive:enforce
+package packageconflict // want "^failed to parse directives"
+
+type Direction int // want Direction:"^N,E,S,W$"
+
+const (
+	N Direction = 1
+	E Direction = 2
+	S Direction = 3
+	W Direction = 4
+)

--- a/testdata/src/package-conflict/b.go
+++ b/testdata/src/package-conflict/b.go
@@ -1,0 +1,2 @@
+//exhaustive:ignore
+package packageconflict

--- a/testdata/src/package-enforce/explicit-map/direction.go
+++ b/testdata/src/package-enforce/explicit-map/direction.go
@@ -1,0 +1,12 @@
+//exhaustive:enforce
+package explicitmap
+
+type Direction int // want Direction:"^N,E,S,W,directionInvalid$"
+
+const (
+	N                Direction = 1
+	E                Direction = 2
+	S                Direction = 3
+	W                Direction = 4
+	directionInvalid Direction = 5
+)

--- a/testdata/src/package-enforce/explicit-map/explicit_map.go
+++ b/testdata/src/package-enforce/explicit-map/explicit_map.go
@@ -1,0 +1,34 @@
+package explicitmap
+
+// Package-level enforce: all map literals in the package should be checked
+// even in explicit mode, without per-map //exhaustive:enforce.
+
+func _enforced() {
+	// this should report: package-level enforce is active.
+	_ = map[Direction]string{ // want "^missing keys in map of key type explicitmap.Direction: explicitmap.E, explicitmap.directionInvalid$"
+		N: "north",
+		S: "south",
+		W: "west",
+	}
+}
+
+func _ignoredOverride() {
+	// this should not report: per-map ignore overrides package-level enforce.
+	//exhaustive:ignore
+	_ = map[Direction]string{
+		N: "north",
+		S: "south",
+		W: "west",
+	}
+}
+
+func _exhaustive() {
+	// this should not report: all members are listed.
+	_ = map[Direction]string{
+		N:                "north",
+		E:                "east",
+		S:                "south",
+		W:                "west",
+		directionInvalid: "invalid",
+	}
+}

--- a/testdata/src/package-enforce/explicit-switch/direction.go
+++ b/testdata/src/package-enforce/explicit-switch/direction.go
@@ -1,0 +1,12 @@
+//exhaustive:enforce
+package explicitswitch
+
+type Direction int // want Direction:"^N,E,S,W,directionInvalid$"
+
+const (
+	N                Direction = 1
+	E                Direction = 2
+	S                Direction = 3
+	W                Direction = 4
+	directionInvalid Direction = 5
+)

--- a/testdata/src/package-enforce/explicit-switch/explicit_switch.go
+++ b/testdata/src/package-enforce/explicit-switch/explicit_switch.go
@@ -1,0 +1,80 @@
+package explicitswitch
+
+// Package-level enforce: all switches in the package should be checked
+// even in explicit mode, without per-switch //exhaustive:enforce.
+
+func _enforced() {
+	var d Direction
+
+	// this should report: package-level enforce is active.
+	switch d { // want "^missing cases in switch of type explicitswitch.Direction: explicitswitch.E, explicitswitch.directionInvalid$"
+	case N:
+	case S:
+	case W:
+	default:
+	}
+}
+
+func _ignoredOverride() {
+	var d Direction
+
+	// this should not report: per-switch ignore overrides package-level enforce.
+	//exhaustive:ignore
+	switch d {
+	case N:
+	case S:
+	case W:
+	default:
+	}
+}
+
+func _exhaustive() {
+	var d Direction
+
+	// this should not report: all members are listed.
+	switch d {
+	case N:
+	case E:
+	case S:
+	case W:
+	case directionInvalid:
+	}
+}
+
+func _nested() {
+	var d Direction
+
+	// outer should report.
+	switch d { // want "^missing cases in switch of type explicitswitch.Direction: explicitswitch.E, explicitswitch.directionInvalid$"
+	case N:
+	case S:
+	case W:
+	default:
+		// inner should also report: package-level enforce applies to nested switches.
+		switch d { // want "^missing cases in switch of type explicitswitch.Direction: explicitswitch.directionInvalid$"
+		case N:
+		case E:
+		case S:
+		case W:
+		default:
+		}
+	}
+}
+
+func _nestedIgnored() {
+	var d Direction
+
+	// outer should report.
+	switch d { // want "^missing cases in switch of type explicitswitch.Direction: explicitswitch.E, explicitswitch.directionInvalid$"
+	case N:
+	case S:
+	case W:
+	default:
+		// inner should not report: per-switch ignore.
+		//exhaustive:ignore
+		switch d {
+		case N:
+		default:
+		}
+	}
+}

--- a/testdata/src/package-enforce/implicit-switch/direction.go
+++ b/testdata/src/package-enforce/implicit-switch/direction.go
@@ -1,0 +1,12 @@
+//exhaustive:enforce
+package implicitswitch
+
+type Direction int // want Direction:"^N,E,S,W,directionInvalid$"
+
+const (
+	N                Direction = 1
+	E                Direction = 2
+	S                Direction = 3
+	W                Direction = 4
+	directionInvalid Direction = 5
+)

--- a/testdata/src/package-enforce/implicit-switch/implicit_switch.go
+++ b/testdata/src/package-enforce/implicit-switch/implicit_switch.go
@@ -1,0 +1,29 @@
+package implicitswitch
+
+// Package-level enforce in non-explicit (implicit) mode:
+// switches are checked by default, ignore still works.
+
+func _checked() {
+	var d Direction
+
+	// this should report: normal implicit checking.
+	switch d { // want "^missing cases in switch of type implicitswitch.Direction: implicitswitch.E, implicitswitch.directionInvalid$"
+	case N:
+	case S:
+	case W:
+	default:
+	}
+}
+
+func _ignored() {
+	var d Direction
+
+	// this should not report: per-switch ignore.
+	//exhaustive:ignore
+	switch d {
+	case N:
+	case S:
+	case W:
+	default:
+	}
+}

--- a/testdata/src/package-enforce/no-directive/direction.go
+++ b/testdata/src/package-enforce/no-directive/direction.go
@@ -1,0 +1,11 @@
+package nodirective
+
+type Direction int // want Direction:"^N,E,S,W,directionInvalid$"
+
+const (
+	N                Direction = 1
+	E                Direction = 2
+	S                Direction = 3
+	W                Direction = 4
+	directionInvalid Direction = 5
+)

--- a/testdata/src/package-enforce/no-directive/no_directive.go
+++ b/testdata/src/package-enforce/no-directive/no_directive.go
@@ -1,0 +1,29 @@
+package nodirective
+
+// No package-level enforce: in explicit mode, switches without
+// per-switch enforce should not be checked.
+
+func _notChecked() {
+	var d Direction
+
+	// this should not report: no enforce directive anywhere.
+	switch d {
+	case N:
+	case S:
+	case W:
+	default:
+	}
+}
+
+func _enforced() {
+	var d Direction
+
+	// this should report: per-switch enforce.
+	//exhaustive:enforce
+	switch d { // want "^missing cases in switch of type nodirective.Direction: nodirective.E, nodirective.directionInvalid$"
+	case N:
+	case S:
+	case W:
+	default:
+	}
+}

--- a/testdata/src/package-ignore/implicit-map/direction.go
+++ b/testdata/src/package-ignore/implicit-map/direction.go
@@ -1,0 +1,12 @@
+//exhaustive:ignore
+package implicitmap
+
+type Direction int // want Direction:"^N,E,S,W,directionInvalid$"
+
+const (
+	N                Direction = 1
+	E                Direction = 2
+	S                Direction = 3
+	W                Direction = 4
+	directionInvalid Direction = 5
+)

--- a/testdata/src/package-ignore/implicit-map/implicit_map.go
+++ b/testdata/src/package-ignore/implicit-map/implicit_map.go
@@ -1,0 +1,34 @@
+package implicitmap
+
+// Package-level ignore: all map literals in the package should be skipped
+// in non-explicit (implicit) mode, without per-map //exhaustive:ignore.
+
+func _ignored() {
+	// this should not report: package-level ignore is active.
+	_ = map[Direction]string{
+		N: "north",
+		S: "south",
+		W: "west",
+	}
+}
+
+func _enforceOverride() {
+	// this should report: per-map enforce overrides package-level ignore.
+	//exhaustive:enforce
+	_ = map[Direction]string{ // want "^missing keys in map of key type implicitmap.Direction: implicitmap.E, implicitmap.directionInvalid$"
+		N: "north",
+		S: "south",
+		W: "west",
+	}
+}
+
+func _exhaustive() {
+	// this should not report: all members are listed (and package-level ignore).
+	_ = map[Direction]string{
+		N:                "north",
+		E:                "east",
+		S:                "south",
+		W:                "west",
+		directionInvalid: "invalid",
+	}
+}

--- a/testdata/src/package-ignore/implicit-switch/direction.go
+++ b/testdata/src/package-ignore/implicit-switch/direction.go
@@ -1,0 +1,12 @@
+//exhaustive:ignore
+package implicitswitch
+
+type Direction int // want Direction:"^N,E,S,W,directionInvalid$"
+
+const (
+	N                Direction = 1
+	E                Direction = 2
+	S                Direction = 3
+	W                Direction = 4
+	directionInvalid Direction = 5
+)

--- a/testdata/src/package-ignore/implicit-switch/implicit_switch.go
+++ b/testdata/src/package-ignore/implicit-switch/implicit_switch.go
@@ -1,0 +1,79 @@
+package implicitswitch
+
+// Package-level ignore: all switches in the package should be skipped
+// in non-explicit (implicit) mode, without per-switch //exhaustive:ignore.
+
+func _ignored() {
+	var d Direction
+
+	// this should not report: package-level ignore is active.
+	switch d {
+	case N:
+	case S:
+	case W:
+	default:
+	}
+}
+
+func _enforceOverride() {
+	var d Direction
+
+	// this should report: per-switch enforce overrides package-level ignore.
+	//exhaustive:enforce
+	switch d { // want "^missing cases in switch of type implicitswitch.Direction: implicitswitch.E, implicitswitch.directionInvalid$"
+	case N:
+	case S:
+	case W:
+	default:
+	}
+}
+
+func _exhaustive() {
+	var d Direction
+
+	// this should not report: all members are listed (and package-level ignore).
+	switch d {
+	case N:
+	case E:
+	case S:
+	case W:
+	case directionInvalid:
+	}
+}
+
+func _nested() {
+	var d Direction
+
+	// outer should not report: package-level ignore.
+	switch d {
+	case N:
+	case S:
+	case W:
+	default:
+		// inner should also not report: package-level ignore applies to nested switches.
+		switch d {
+		case N:
+		default:
+		}
+	}
+}
+
+func _nestedEnforced() {
+	var d Direction
+
+	// outer should not report: package-level ignore.
+	switch d {
+	case N:
+	case S:
+	case W:
+	default:
+		// inner should report: per-switch enforce overrides.
+		//exhaustive:enforce
+		switch d { // want "^missing cases in switch of type implicitswitch.Direction: implicitswitch.E, implicitswitch.directionInvalid$"
+		case N:
+		case S:
+		case W:
+		default:
+		}
+	}
+}


### PR DESCRIPTION
Support placing //exhaustive:enforce or //exhaustive:ignore on a package clause to apply exhaustive checking policy to all switch statements and map literals in the package. Per-statement directives override the package-level directive.